### PR TITLE
Set eFuse bit to expected value by not modifying

### DIFF
--- a/firmware/util.pl
+++ b/firmware/util.pl
@@ -30,9 +30,6 @@ if(@ARGV && ($ARGV[0] eq "fuse" || $ARGV[0] eq "vfuse")) {
     my $high_fuse     = hex $2;
     my $extended_fuse = hex $3;
 
-    # strip reserved fuse bits
-    $extended_fuse &= 0x07;
-
     # print avrdude fuse bit options
     if($ARGV[0] eq "fuse") {
 	printf "-u -U lfuse:w:0x%02X:m\n", $low_fuse;


### PR DESCRIPTION
When running make install-fuse the script attempts to set efuse to 0x06
while I expect it to attempt to write 0xFE.

Removing the bitwise and of 0x07 on the value 0xFE resulted in 0xFE
being flashed to the extended fuse as expected.